### PR TITLE
Exclude jakarta.validation-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>9.0.0.Final</version>
+            <exclusions>
+                    <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Version Incompatibility
You're using:

- validation-api:2.0.1.Final (Jakarta Bean Validation 2.0)

- hibernate-validator:9.0.0.Final

However, Hibernate Validator 9.0.0.Final is based on Jakarta Bean Validation 3.0, which uses the jakarta.validation package (not javax.validation).

This mismatch is likely causing the ConfigurationImpl class to fail during initialization.

One solution is: Upgrade to Jakarta Validation 3.0. But unfortunately that is not working. So I am excluding the other dependency which is coming with hibernate-validator.
