### PR TITLE
Upgrade java and spring boot version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Setup Java 17
+    - name: Setup Java 25
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 25
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [25]
         
     runs-on: ubuntu-latest
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -59,13 +59,11 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.18.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.34</version>
         </dependency>
 
         <!-- Spring Security -->
@@ -73,12 +71,10 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.24.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.3</version>
         </dependency>
 
         <!-- @Inject -->
@@ -105,7 +101,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>8.0.2.Final</version>
         </dependency>
 
         <dependency>
@@ -117,13 +112,11 @@
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-            <version>3.0.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-            <version>3.0.1</version>
         </dependency>
         <!-- Servlet -->
         <!--<dependency>
@@ -157,14 +150,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.13.0</version>
         </dependency>
 
         <!-- DB Driver -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.6</version>
         </dependency>
 
         <dependency>
@@ -183,7 +174,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -243,7 +233,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <runOrder>alphabetical</runOrder>
                     <useSystemClassLoader>false</useSystemClassLoader>


### PR DESCRIPTION
This update modernizes the application by upgrading the Spring Boot parent to 3.5.11 and aligning the project with Java 25.

Key changes:
- Updated spring-boot-starter-parent to 3.5.11, which is compatible with Java 17–25 per Spring Boot’s official compatibility matrix.
- Updated java.version property to 25, enabling compilation and runtime compatibility with the latest Java LTS release.
- Removed several explicit dependency versions that are now managed automatically by the Spring Boot 3.5.x BOM (expected behaviour when upgrading the parent).

Why this change:
- Ensures long-term support and alignment with the latest Spring ecosystem.
- Allows use of new JVM features introduced in Java 25.
- Reduces version conflicts by relying on Spring Boot dependency management.

No functional changes were introduced—this PR focuses solely on platform and build modernization.