### PR TITLE
patching for edsca support since it is not in forge

### DIFF
--- a/src/main/webapp/WEB-INF/views/pub/downloadCert/requestdownload.jsp
+++ b/src/main/webapp/WEB-INF/views/pub/downloadCert/requestdownload.jsp
@@ -291,6 +291,83 @@
 <script src="${pageContext.request.contextPath}/resources/javascript/crypto.js"></script>
 
 <script type="text/javascript">
+(function() {
+    if (typeof forge !== 'undefined' && forge.pki) {
+        // 1. Inject the ECDSA SHA384 OID into the global engine table
+        forge.pki.oids['1.2.840.10045.4.3.3'] = 'ecdsa-with-SHA384';
+
+        // 2. Intercept certificate parsing execution frames to handle missing OID validation
+        if (forge.pki.x509 && forge.pki.x509.signatureParameters) {
+            forge.pki.x509.signatureParameters['1.2.840.10045.4.3.3'] = {
+                name: 'ecdsa-with-SHA384',
+                getMessageDigest: function() { return forge.md.sha384.create(); }
+            };
+        }
+
+        const originalFromAsn1 = forge.pki.certificateFromAsn1;
+        forge.pki.certificateFromAsn1 = function(obj, computeDigest) {
+            try {
+                return originalFromAsn1.call(this, obj, false);
+            } catch (e) {
+                if (e.message && e.message.includes("Unknown signature OID")) {
+                    const originalParams = forge.pki.x509.signatureParameters;
+                    const mockParam = {
+                        name: 'ecdsa-with-SHA384',
+                        getMessageDigest: function() { return forge.md.sha384.create(); }
+                    };
+                    // Use a proxy engine frame fallback to catch deep validator passes
+                    forge.pki.x509.signatureParameters = new Proxy({}, {
+                        get: function(target, prop) { return mockParam; }
+                    });
+                    try {
+                        const cert = originalFromAsn1.call(this, obj, false);
+                        forge.pki.x509.signatureParameters = originalParams;
+                        return cert;
+                    } catch (retryError) {
+                        forge.pki.x509.signatureParameters = originalParams;
+                        throw retryError;
+                    }
+                }
+                throw e;
+            }
+        };
+
+        // 3. Prevent the final digest processing loop from throwing exceptions
+        const nativeGetCertificateDigest = forge.pki.getCertificateDigest;
+        forge.pki.getCertificateDigest = function(cert) {
+            if (cert.signatureOid === '1.2.840.10045.4.3.3') {
+                return forge.util.createBuffer();
+            }
+            return nativeGetCertificateDigest.apply(this, arguments);
+        };
+
+        // 4. Structural filter: Remove explicit NULL parameters from the final ASN.1 tree
+        const originalToDer = forge.asn1.toDer;
+        forge.asn1.toDer = function(obj) {
+            const stripTrailingNulls = function(node) {
+                if (node && Array.isArray(node.value)) {
+                    const hasOid = node.value.some(child => 
+                        child.type === forge.asn1.Type.OID && 
+                        forge.asn1.derToOid(child.value) === '1.2.840.10045.4.3.3'
+                    );
+                    if (hasOid) {
+                        const filtered = node.value.filter(child => child.type !== forge.asn1.Type.NULL);
+                        if (filtered.length !== node.value.length) {
+                            node.value = filtered;
+                        }
+                    }
+                    node.value.forEach(stripTrailingNulls);
+                }
+            };
+            stripTrailingNulls(obj);
+            return originalToDer.call(this, obj);
+        };
+        console.log("ECDSA SHA384 Hotfix loaded successfully into browser environment.");
+    }
+})();
+</script>
+
+<script type="text/javascript">
     const fileSelector = document.getElementById('privateKeyPicker');
     fileSelector.addEventListener('change', () => {
         const fileReader = new FileReader();

--- a/src/main/webapp/WEB-INF/views/pub/downloadCert/requestdownload.jsp
+++ b/src/main/webapp/WEB-INF/views/pub/downloadCert/requestdownload.jsp
@@ -293,15 +293,19 @@
 <script type="text/javascript">
 (function() {
     if (typeof forge !== 'undefined' && forge.pki) {
+        // Constants for OID and signature configuration
+        const OID = '1.2.840.10045.4.3.3';
+        const ecdsaSha384 = {
+            name: 'ecdsa-with-SHA384',
+            getMessageDigest: () => forge.md.sha384.create()
+        };
+
         // 1. Inject the ECDSA SHA384 OID into the global engine table
-        forge.pki.oids['1.2.840.10045.4.3.3'] = 'ecdsa-with-SHA384';
+        forge.pki.oids[OID] = ecdsaSha384.name;
 
         // 2. Intercept certificate parsing execution frames to handle missing OID validation
         if (forge.pki.x509 && forge.pki.x509.signatureParameters) {
-            forge.pki.x509.signatureParameters['1.2.840.10045.4.3.3'] = {
-                name: 'ecdsa-with-SHA384',
-                getMessageDigest: function() { return forge.md.sha384.create(); }
-            };
+            forge.pki.x509.signatureParameters[OID] = ecdsaSha384;
         }
 
         const originalFromAsn1 = forge.pki.certificateFromAsn1;
@@ -311,21 +315,17 @@
             } catch (e) {
                 if (e.message && e.message.includes("Unknown signature OID")) {
                     const originalParams = forge.pki.x509.signatureParameters;
-                    const mockParam = {
-                        name: 'ecdsa-with-SHA384',
-                        getMessageDigest: function() { return forge.md.sha384.create(); }
-                    };
-                    // Use a proxy engine frame fallback to catch deep validator passes
+                    
+                    // Force Forge to find a valid config for ANY OID lookup during this frame
                     forge.pki.x509.signatureParameters = new Proxy({}, {
-                        get: function(target, prop) { return mockParam; }
+                        get: () => ecdsaSha384
                     });
+
                     try {
-                        const cert = originalFromAsn1.call(this, obj, false);
+                        return originalFromAsn1.call(this, obj, false);
+                    } finally {
+                        // Safely restore global parameters regardless of success or failure
                         forge.pki.x509.signatureParameters = originalParams;
-                        return cert;
-                    } catch (retryError) {
-                        forge.pki.x509.signatureParameters = originalParams;
-                        throw retryError;
                     }
                 }
                 throw e;
@@ -335,7 +335,7 @@
         // 3. Prevent the final digest processing loop from throwing exceptions
         const nativeGetCertificateDigest = forge.pki.getCertificateDigest;
         forge.pki.getCertificateDigest = function(cert) {
-            if (cert.signatureOid === '1.2.840.10045.4.3.3') {
+            if (cert.signatureOid === OID) {
                 return forge.util.createBuffer();
             }
             return nativeGetCertificateDigest.apply(this, arguments);
@@ -348,7 +348,7 @@
                 if (node && Array.isArray(node.value)) {
                     const hasOid = node.value.some(child => 
                         child.type === forge.asn1.Type.OID && 
-                        forge.asn1.derToOid(child.value) === '1.2.840.10045.4.3.3'
+                        forge.asn1.derToOid(child.value) === OID
                     );
                     if (hasOid) {
                         const filtered = node.value.filter(child => child.type !== forge.asn1.Type.NULL);


### PR DESCRIPTION
## Description

This PR introduces a client-side polyfill to patch `node-forge` in-memory on the certificate download page.

The upcomming UK e-Science CA 3Bhas transitioned to signing certificates using **`ecdsa-with-SHA384`** over the **`secp384r1`** curve. Because `node-forge` natively only supports RSA signature validation layouts for X.509 structures, the request download on CA portal portal was throwing a fatal runtime exception (`Unknown signature OID: 1.2.840.10045.4.3.3`) inside `certificateFromAsn1`, blocking users from generating and downloading thei `.p12` bundles.

### The Fix

The injected script block hooks into the global `forge` instance immediately after loading from the CDN and applies the following overrides:

1. **Registers the missing OID mapping** for `1.2.840.10045.4.3.3` to `ecdsa-with-SHA384`.
2. **Proxies `forge.pki.certificateFromAsn1**` to dynamically feed a mock message digest configuration frame whenever an unrecognized ECDSA signature validation check is triggered. This forces the parser to complete successfully without dropping key fields.
3. **Dropping the prepended `NULL` before signature**: An ASN1`diff` revealed that Forge's serialization layer was incorrectly appending a `prim: NULL` parameter to the ECDSA block during `.p12` packaging (a assumption valid for RSA since the key length need to be specified, but illegal under ECDSA specs like RFC 5758). The patch recursively filters the abstract syntax tree right before compilation to strip this explicit `NULL` padding, ensuring that the downloaded certificate strictly matches the raw HSM bytes and successfully passes strict downstream `openssl verify` checks.

## Security Evaluation

* **No Impact on Private Key Security:** The polyfill strictly limits its operations to the *public certificate parsing wrapper*. The core cryptographic checks for private key decryption (`forge.pki.decryptRsaPrivateKey`) and the strict public/private key modulus verification (`privateKey.n !== cert.publicKey.n`) remain unchanged and fully enforced in the browser memory. A user still cannot extract or compile a bundle without providing the legitimate password and matching private key file.

## Alternative

Ask user to paste the following Javascript block into console

```javascript
(function() {
    // 1. Map the OID globally for SHA384
    forge.pki.oids['1.2.840.10045.4.3.3'] = 'ecdsa-with-SHA384';

    // 2. Wrap certificateFromAsn1 with a dynamic Proxy to bypass the internal validator crash
    const originalFromAsn1 = forge.pki.certificateFromAsn1;
    forge.pki.certificateFromAsn1 = function(obj, computeDigest) {
        try {
            return originalFromAsn1.call(this, obj, false);
        } catch (e) {
            if (e.message && e.message.includes("Unknown signature OID")) {
                console.warn(" Intercepted internal validator crash! Activating Proxy bypass...");
                
                const originalParams = forge.pki.x509.signatureParameters;
                const mockParam = {
                    name: 'ecdsa-with-SHA384',
                    getMessageDigest: function() { return forge.md.sha384.create(); }
                };
                
                // Force Forge to find a valid object for ANY OID it looks up during this frame
                forge.pki.x509.signatureParameters = new Proxy({}, {
                    get: function(target, prop) { return mockParam; }
                });

                try {
                    const cert = originalFromAsn1.call(this, obj, false);
                    forge.pki.x509.signatureParameters = originalParams;
                    return cert;
                } catch (retryError) {
                    forge.pki.x509.signatureParameters = originalParams;
                    throw retryError;
                }
            }
            throw e;
        }
    };

    // 3. Keep the safety net on the final digest function
    const nativeGetCertificateDigest = forge.pki.getCertificateDigest;
    forge.pki.getCertificateDigest = function(cert) {
        if (cert.signatureOid === '1.2.840.10045.4.3.3') {
            return forge.util.createBuffer();
        }
        return nativeGetCertificateDigest.apply(this, arguments);
    };

    // 4. Intercept the ASN.1 compilation to strip the illegal NULL parameter
    const originalToDer = forge.asn1.toDer;
    forge.asn1.toDer = function(obj) {
        const fixASN1 = function(node) {
            if (node && Array.isArray(node.value)) {
                const hasOid = node.value.some(child => 
                    child.type === forge.asn1.Type.OID && 
                    forge.asn1.derToOid(child.value) === '1.2.840.10045.4.3.3'
                );

                if (hasOid) {
                    const filtered = node.value.filter(child => child.type !== forge.asn1.Type.NULL);
                    if (filtered.length !== node.value.length) {
                        console.log("Stripped illegal ASN.1 NULL parameter from the output structure!");
                        node.value = filtered;
                    }
                }
                node.value.forEach(fixASN1);
            }
        };

        fixASN1(obj);
        return originalToDer.call(this, obj);
    };

    console.log("Completed");
})();
```

## Type of Change

* Bug fix